### PR TITLE
Enable simple security checks

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -24,6 +24,7 @@ share/python-wheels/
 *.egg-info/
 .installed.cfg
 *.egg
+.idea
 MANIFEST
 
 # PyInstaller

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -18,6 +18,6 @@ repos:
     hooks:
       - id: secure
         name: secure
-        entry: bandit -r integrify --config pyproject.toml
+        entry: make secure
         language: system
         types: [ python ]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,3 +14,10 @@ repos:
       # Run the linter.
       - id: ruff
         args: [--fix]
+  - repo: local
+    hooks:
+      - id: secure
+        name: secure
+        entry: bandit -r integrify --config pyproject.toml
+        language: system
+        types: [ python ]

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,13 @@
+ifdef OS
+	PYTHON ?= .venv/Scripts/python.exe
+	TYPE_CHECK_COMMAND ?= echo Pytype package doesn't support Windows OS
+else
+	PYTHON ?= .venv/bin/python
+	TYPE_CHECK_COMMAND ?= ${PYTHON} -m pytype --config=pytype.cfg src
+endif
+
+SETTINGS_FILENAME = pyproject.toml
+
+
+secure:
+	${PYTHON} -m bandit -r integrify --config ${SETTINGS_FILENAME}

--- a/integrify/base.py
+++ b/integrify/base.py
@@ -76,7 +76,7 @@ class SyncApiRequest(ApiRequest):
 
     def __call__(self, *args: Any, **kwds: Any):
         if not self.session:
-            self.session = httpx.Client()
+            self.session = httpx.Client(timeout=10)
 
         resp = self.session.request(self.verb, self.url, data=self.body, headers=self.headers)  # type: ignore[arg-type]
         return self.process_response(resp)
@@ -87,7 +87,7 @@ class AsyncApiRequest(ApiRequest):
 
     async def __call__(self, *args, **kwds):
         if not self.session:
-            self.session = httpx.AsyncClient()
+            self.session = httpx.AsyncClient(timeout=10)
 
         resp = await self.session.request(
             self.verb,

--- a/integrify/epoint/helper.py
+++ b/integrify/epoint/helper.py
@@ -1,7 +1,7 @@
 import base64
 import json
 
-from hashlib import sha256
+from hashlib import sha1
 from integrify.epoint import env
 from integrify.epoint.schemas.types import CallbackDataSchema, DecodedCallbackDataSchema
 
@@ -10,7 +10,7 @@ __all__ = ['generate_signature', 'decode_callback_data']
 
 def generate_signature(data: str) -> str:
     sgn_string = env.EPOINT_PRIVATE_KEY + data + env.EPOINT_PRIVATE_KEY
-    return base64.b64encode(sha256(sgn_string.encode()).digest()).decode()
+    return base64.b64encode(sha1(sgn_string.encode(), usedforsecurity=False).digest()).decode()
 
 
 def decode_callback_data(data: CallbackDataSchema) -> DecodedCallbackDataSchema:

--- a/integrify/epoint/helper.py
+++ b/integrify/epoint/helper.py
@@ -1,7 +1,7 @@
 import base64
 import json
-from hashlib import sha1
 
+from hashlib import sha256
 from integrify.epoint import env
 from integrify.epoint.schemas.types import CallbackDataSchema, DecodedCallbackDataSchema
 
@@ -10,7 +10,7 @@ __all__ = ['generate_signature', 'decode_callback_data']
 
 def generate_signature(data: str) -> str:
     sgn_string = env.EPOINT_PRIVATE_KEY + data + env.EPOINT_PRIVATE_KEY
-    return base64.b64encode(sha1(sgn_string.encode()).digest()).decode()
+    return base64.b64encode(sha256(sgn_string.encode()).digest()).decode()
 
 
 def decode_callback_data(data: CallbackDataSchema) -> DecodedCallbackDataSchema:

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -77,3 +77,6 @@ quote-style = "single"
 [tool.ruff.lint.flake8-quotes]
 docstring-quotes = "double"
 
+[tool.bandit]
+skips = []
+

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -54,6 +54,7 @@ pre-commit = "^3.6.2"
 ptpython = "^3.0.29"
 mkdocs-material = "^9.5.36"
 mkdocstrings = {extras = ["python"], version = "^0.26.1"}
+bandit = "^1.7.10"
 
 [tool.ruff]
 target-version = "py311"


### PR DESCRIPTION
Changes:

* Add explicit timeouts for `httpx` clients.
* Use `sha256` instead of `sha1` - as sha1 is considered as "dead".